### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,11 +1,7 @@
-pull_request_rules:
-  - name: Automatically merge Renovate PRs
-    conditions:
-      - author = renovate[bot]
-    actions:
-      queue:
-queue_rules:
-  - queue_branch_merge_method: fast-forward
-    allow_queue_branch_edit: true
-    update_method: merge
-    name: default
+merge_protections:
+  - name: Only merge with chore(deps)
+    description: ""
+    if:
+      - base = main
+    success_conditions:
+      - "title ~= ^chore\\(deps\\):"


### PR DESCRIPTION
This change has been made by @MH0386 from the Mergify merge protections editor.

## Summary by Sourcery

CI:
- Updates the Mergify configuration to only allow merging pull requests with titles starting with 'chore(deps):' into the main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised automated merging settings with a stricter policy for dependency update requests, ensuring that merges only occur under specific conditions on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->